### PR TITLE
Python 3 dependencies for ROS Noetic

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,7 +19,8 @@
     <depend>libpqxx</depend>
     <depend>libpqxx-dev</depend>
     <depend>postgresql</depend>
-    <depend>python-dev</depend>
+    <depend condition="$ROS_PYTHON_VERSION == 2">python</depend>
+    <depend condition="$ROS_PYTHON_VERSION == 3">python3</depend>
     <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-imaging</exec_depend>
     <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pil</exec_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -20,8 +20,8 @@
     <depend>libpqxx-dev</depend>
     <depend>postgresql</depend>
     <depend>python-dev</depend>
-    <exec_depend>python-imaging</exec_depend>
-    <exec_depend>python3-pil</exec_depend>
+    <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-imaging</exec_depend>
+    <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-pil</exec_depend>
 
     <test_depend>rosunit</test_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
     <name>knowledge_representation</name>
     <version>0.9.1</version>
     <description>APIs for storing and querying information about the world.
@@ -11,6 +11,8 @@
     <license>BSD</license>
 
     <buildtool_depend>catkin</buildtool_depend>
+    <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+    <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
     <build_depend>roslint</build_depend>
 
     <depend>boost</depend>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml


### PR DESCRIPTION
[ROS Noetic targets Python 3](https://www.ros.org/reps/rep-0003.html#noetic-ninjemys-may-2020-may-2025), but this package has python 2 dependencies. This PR is part of the way towards Python 3, but it is probably not enough because it doesn't change any code.

https://github.com/utexas-bwi/knowledge_representation/blob/bd90d07600bf1198b9927d946a52785609973643/CMakeLists.txt#L11

* Uses format 3 and conditional dependencies
* Uses setuptools because of ros/catkin#1048
* Use `python` instead of `python-dev` key (both point to `-dev` packages), but there's a matching `python3` key.

See this guide for more info about using Python 3 in ROS packages: http://wiki.ros.org/UsingPython3/
See also the migration guide for ROS Noetic: http://wiki.ros.org/noetic/Migration